### PR TITLE
Style/plans responsive

### DIFF
--- a/src/component/Plans-responsive/Plans-responsive.jsx
+++ b/src/component/Plans-responsive/Plans-responsive.jsx
@@ -73,7 +73,7 @@ export default function PlansResponsive() {
                     : "max-h-0 opacity-0"
                 }`}
               >
-                <div className="flex flex-col items-center text-center max-w-full relative">
+                <div className="flex flex-col items-center text-center max-w-full relative p-4">
                   <div className="text-left px-8 max-w-7xl">
                     <h2 className="text-2xl font-bold text-gray-800 mb-4 whitespace-pre-line text-center">
                       {plans[index][1].title}

--- a/src/component/Plans-responsive/Plans-responsive.jsx
+++ b/src/component/Plans-responsive/Plans-responsive.jsx
@@ -39,11 +39,7 @@ export default function PlansResponsive() {
                 className={`
                 flex items-center gap-4 p-4 rounded-lg shadow-md w-full
                 transition-all cursor-pointer duration-700 transform
-                ${
-                  plan === key
-                    ? "border-1 border-indigo-400 bg-blue-50"
-                    : "bg-white"
-                }
+                ${plan === key ? "border-shadow bg-blue-50" : "bg-white"}
                 ${
                   visibleItems.includes(index.toString())
                     ? "opacity-100 translate-y-0"

--- a/src/index.css
+++ b/src/index.css
@@ -92,3 +92,9 @@
     @apply w-[150px] min-w-[150px] mx-4;
   }
 }
+
+.border-shadow {
+  box-shadow: 0px 0px 0px 2px rgba(129, 140, 248, 1);
+  -webkit-box-shadow: 0px 0px 0px 2px rgba(129, 140, 248, 1);
+  -moz-box-shadow: 0px 0px 0px 2px rgba(129, 140, 248, 1);
+}


### PR DESCRIPTION
This pull request focuses on improving the visual presentation of our cards. I encountered difficulties when attempting to apply direct borders, so I've introduced a **shadow effect on the index element to simulate a border**. A new CSS class has been added to manage these styles. Furthermore, I've included **padding within the plan content cards**. This adjustment provides better spacing and ensures that the figures within them are more clearly visible.